### PR TITLE
perf: 유사도 계산 벡터화

### DIFF
--- a/similarity/utils.py
+++ b/similarity/utils.py
@@ -5,57 +5,99 @@ import numpy as np
 
 
 def get_stock_trend_with_dates(stockid, days=30):
-
     qs = ClosingPriceLog.objects.filter(stockid=stockid).order_by('-date')[:days]
     qs = list(qs)[::-1]  
-    closing_prices = [row.closing_price for row in qs]
-    updown_rates = [row.updown_rate for row in qs]
-    dates = [row.date.date() for row in qs]  
+    
+    closing_prices = np.array([row.closing_price for row in qs])
+    updown_rates = np.array([row.updown_rate for row in qs])
+    dates = np.array([row.date.date() for row in qs])
+    
     return closing_prices, updown_rates, dates
 
-def zscore_normalize(vec):
-    arr = np.array(vec)
-    return (arr - arr.mean()) / (arr.std() + 1e-8)
 
-def dtw_distance(a, b):
-    n, m = len(a), len(b)
-    dtw = np.full((n+1, m+1), np.inf)
-    dtw[0, 0] = 0
-    for i in range(1, n+1):
-        for j in range(1, m+1):
-            cost = abs(a[i-1] - b[j-1])
-            dtw[i, j] = cost + min(dtw[i-1, j], dtw[i, j-1], dtw[i-1, j-1])
-    return dtw[n, m]
-
-
-def similarity_dtw_price(stockid1, stockid2, days=30):
-    prices1, _, dates1 = get_stock_trend_with_dates(stockid1, days)
-    prices2, _, dates2 = get_stock_trend_with_dates(stockid2, days)
-
-    common_dates = set(dates1) & set(dates2)
-    common_prices1 = []
-    common_prices2 = []
+def batch_get_stock_trends(stockids, days=30):
+    all_data = {}
     
-    for date in sorted(common_dates):
-        if date in dates1 and date in dates2:
-            idx1 = dates1.index(date)
-            idx2 = dates2.index(date)
-            common_prices1.append(prices1[idx1])
-            common_prices2.append(prices2[idx2])
+    for stockid in stockids:
+        try:
+            prices, _, dates = get_stock_trend_with_dates(stockid, days)
+            all_data[stockid] = (prices, dates)
+        except Exception:
+            continue
     
-    price1_norm = zscore_normalize(common_prices1)
-    price2_norm = zscore_normalize(common_prices2)
-    price_dist = dtw_distance(price1_norm, price2_norm)
-    price_sim = 1 / (1 + price_dist)
-    
-    #print(f"{stockid1} vs {stockid2} - DTW 거리: {price_dist}, 유사도: {price_sim}")
-    
-    return price_sim
+    return all_data
 
 
-def get_top5_stocks_by_value(userid):
-    mystocks = MyStock.objects.filter(userid=userid)
+def find_common_dates(all_stock_data):
+    if not all_stock_data:
+        return np.array([])
+    
+    common_dates = set(all_stock_data[list(all_stock_data.keys())[0]][1])
+    
+    for stockid, (_, dates) in all_stock_data.items():
+        common_dates = common_dates.intersection(set(dates))
+    
+    return np.array(sorted(list(common_dates)))
+
+
+def extract_prices_for_dates(prices, dates, target_dates):
+    if len(target_dates) == 0:
+        return np.array([])
+    
+    date_indices = []
+    for target_date in target_dates:
+        matches = np.where(dates == target_date)[0]
+        if len(matches) > 0:
+            date_indices.append(matches[0])
+    
+    if len(date_indices) == 0:
+        return np.array([])
+    
+    return prices[date_indices]
+
+
+def create_price_matrix(stockids, all_stock_data, common_dates):
+    if len(common_dates) == 0:
+        return np.array([]), []
+    
+    valid_stockids = []
+    price_matrix = []
+    
+    for stockid in stockids:
+        if stockid in all_stock_data:
+            prices, dates = all_stock_data[stockid]
+            extracted_prices = extract_prices_for_dates(prices, dates, common_dates)
+            
+            if len(extracted_prices) == len(common_dates):
+                price_matrix.append(extracted_prices)
+                valid_stockids.append(stockid)
+    
+    return np.array(price_matrix), valid_stockids
+
+
+def vectorized_dtw_similarity(target_prices, price_matrix):
+    if len(price_matrix) == 0:
+        return np.array([])
+    
+    similarities = np.zeros(len(price_matrix))
+    
+    for i in range(len(price_matrix)):
+        if len(target_prices) >= 5 and len(price_matrix[i]) >= 5:
+            target_norm = zscore_normalize(target_prices)
+            stock_norm = zscore_normalize(price_matrix[i])
+            
+            price_dist = dtw_distance(target_norm, stock_norm)
+            similarities[i] = 1 / (1 + price_dist)
+        else:
+            similarities[i] = 0.0
+    
+    return similarities
+
+
+def batch_get_user_stock_info(user_id):
+    mystocks = MyStock.objects.filter(userid=user_id)
     result = []
+    
     for ms in mystocks:
         try:
             stock = Stock.objects.get(id=ms.stockid)
@@ -64,8 +106,125 @@ def get_top5_stocks_by_value(userid):
                 result.append((ms.stockid, stock.name, value, ms.cnt, stock.current_price))
         except Stock.DoesNotExist:
             continue
-    result.sort(key=lambda x: x[2], reverse=True) 
-    return result[:5] #상위 5개 
+    
+    result.sort(key=lambda x: x[2], reverse=True)
+    return result[:5]
+
+
+def batch_get_industry_names(stockids):
+    industry_names = {}
+    stocks = Stock.objects.filter(id__in=stockids)
+    
+    for stock in stocks:
+        try:
+            industry = Industry.objects.get(industry_code=stock.industry_code)
+            industry_names[stock.id] = industry.industry_name
+        except Industry.DoesNotExist:
+            industry_names[stock.id] = None
+    
+    return industry_names
+
+
+def batch_get_stock_types(stockids):
+    stock_types = {}
+    stocks = Stock.objects.filter(id__in=stockids)
+    
+    for stock in stocks:
+        stock_types[stock.id] = stock.type
+    
+    return stock_types
+
+
+def vectorized_weighted_similarity(target_stockid, user_id, category_stockids, days=30):
+    all_stock_data = batch_get_stock_trends(category_stockids, days)
+    user_stocks = batch_get_user_stock_info(user_id)
+    
+    if not user_stocks or not all_stock_data:
+        return np.zeros(len(category_stockids)), np.zeros(len(category_stockids))
+    
+    common_dates = find_common_dates(all_stock_data)
+    
+    if len(common_dates) < 5:
+        return np.zeros(len(category_stockids)), np.zeros(len(category_stockids))
+    
+    price_matrix, valid_stockids = create_price_matrix(category_stockids, all_stock_data, common_dates)
+    
+    if len(price_matrix) == 0:
+        return np.zeros(len(category_stockids)), np.zeros(len(category_stockids))
+    
+    user_stockids = [stock[0] for stock in user_stocks]
+    user_stock_data = batch_get_stock_trends(user_stockids, days)
+    
+    all_stockids = list(set(category_stockids + user_stockids))
+    industry_names = batch_get_industry_names(all_stockids)
+    stock_types = batch_get_stock_types(all_stockids)
+    
+    total_price_similarities = np.zeros(len(valid_stockids))
+    total_industry_similarities = np.zeros(len(valid_stockids))
+    total_type_similarities = np.zeros(len(valid_stockids))
+    total_value = sum([stock[2] for stock in user_stocks])
+    
+    for user_stockid, name, value, cnt, current_price in user_stocks:
+        if user_stockid in user_stock_data:
+            user_prices, user_dates = user_stock_data[user_stockid]
+            user_extracted_prices = extract_prices_for_dates(user_prices, user_dates, common_dates)
+            
+            if len(user_extracted_prices) == len(common_dates):
+                price_similarities = vectorized_dtw_similarity(user_extracted_prices, price_matrix)
+                
+                user_industry = industry_names.get(user_stockid)
+                industry_similarities = np.array([
+                    get_industry_similarity(user_industry, industry_names.get(stockid))
+                    for stockid in valid_stockids
+                ])
+                
+                user_type = stock_types.get(user_stockid)
+                type_similarities = np.array([
+                    get_type_similarity_from_types(user_type, stock_types.get(stockid))
+                    for stockid in valid_stockids
+                ])
+                
+                weight = value / total_value if total_value > 0 else 0
+                total_price_similarities += price_similarities * weight
+                total_industry_similarities += industry_similarities * weight
+                total_type_similarities += type_similarities * weight
+    
+    total_similarities = (total_price_similarities + total_industry_similarities + total_type_similarities) / 3
+    
+    pattern_result = np.zeros(len(category_stockids))
+    bs_result = np.zeros(len(category_stockids))
+    
+    for i, stockid in enumerate(category_stockids):
+        if stockid in valid_stockids:
+            valid_idx = valid_stockids.index(stockid)
+            pattern_result[i] = round(total_price_similarities[valid_idx] * 100, 2)  # 패턴 점수 (소수점 2자리)
+            bs_result[i] = round(total_similarities[valid_idx], 2)  # 종합 점수 (소수점 2자리)
+    
+    return pattern_result, bs_result
+
+
+def zscore_normalize(vec):
+    arr = np.array(vec)
+    if len(arr) == 0:
+        return arr
+    return (arr - arr.mean()) / (arr.std() + 1e-8)
+
+
+def dtw_distance(a, b):
+    n, m = len(a), len(b)
+    dtw = np.full((n+1, m+1), np.inf)
+    dtw[0, 0] = 0
+    
+    a_arr = np.array(a)
+    b_arr = np.array(b)
+    
+    for i in range(1, n+1):
+        for j in range(1, m+1):
+            cost = abs(a_arr[i-1] - b_arr[j-1])
+            dtw[i, j] = cost + min(dtw[i-1, j], dtw[i, j-1], dtw[i-1, j-1])
+    
+    return dtw[n, m]
+
 
 def get_industry_name_by_stockid(stockid):
     try:
@@ -75,114 +234,64 @@ def get_industry_name_by_stockid(stockid):
     except (Stock.DoesNotExist, Industry.DoesNotExist):
         return None
 
-def get_type_by_stockid(stockid):
-    try:
-        stock = Stock.objects.get(id=stockid)
-        return stock.type
-    except Stock.DoesNotExist:
-        return None
 
-# Clova Studio API 
 def get_industry_similarity(name1, name2):
     if name1 is None or name2 is None:
         return 0.3  
     if name1 == name2:
         return 1.0
-    return 0.5  # 임시값
+    return 0.5
 
-# type 유사도 매트릭스
+
 TYPE_SIM_MATRIX = {
     '성장주': {'성장주': 1.0, '가치주': 0.4, '배당주': 0.2},
     '가치주': {'성장주': 0.4, '가치주': 1.0, '배당주': 0.5},
     '배당주': {'성장주': 0.2, '가치주': 0.5, '배당주': 1.0},
 }
 
-def get_type_similarity(stockid1, stockid2):
-    type1 = get_type_by_stockid(stockid1)
-    type2 = get_type_by_stockid(stockid2)
+
+def get_type_similarity_from_types(type1, type2):
     if not type1 or not type2:
         return 0.3  
     return TYPE_SIM_MATRIX.get(type1, {}).get(type2, 0.3)
 
-def calculate_weighted_similarity(target_stockid, user_id, days=30):
- 
-    # 상위 5개 보유 종목
-    top5 = get_top5_stocks_by_value(user_id)
-    total_value = sum([x[2] for x in top5])
-    weighted_price_sim = 0.0
-    weighted_industry_sim = 0.0
-    weighted_type_sim = 0.0
-    target_industry = get_industry_name_by_stockid(target_stockid)
-    
-    #print(f"target_stockid={target_stockid}, user_id={user_id}")
-    #print(f"top5 count={len(top5)}, total_value={total_value}")
-    
-    for stockid, name, value, cnt, current_price in top5:
-        weight = value / total_value if total_value > 0 else 0
-        # 패턴
-        price_sim = similarity_dtw_price(target_stockid, stockid, days)
-        # 업종 유사도
-        industry_name = get_industry_name_by_stockid(stockid)
-        industry_sim = get_industry_similarity(target_industry, industry_name)
-        # type 유사도
-        type_sim = get_type_similarity(target_stockid, stockid)
-        
-        #print(f"stockid={stockid}, weight={weight}, price_sim={price_sim}")
-        
-        weighted_price_sim += price_sim * weight
-        weighted_industry_sim += industry_sim * weight
-        weighted_type_sim += type_sim * weight
-    
-    
-    # 종합 유사도 (가격, 업종, 타입 유사도의 평균)
-    total_weighted_similarity = (weighted_price_sim + weighted_industry_sim + weighted_type_sim) / 3
-    
-    pattern_score = weighted_price_sim * 100
-    #print(f"패턴 점수 (가격 유사도 * 100): {pattern_score}")
-    
-    return {
-        'pattern': pattern_score,
-        'bs': round(total_weighted_similarity, 2)
-    } 
 
 def get_most_similar_stock_by_category(category_id, user_id, days=30):
-    
     category_stockids = get_stockids_by_category(category_id)
     
     if not category_stockids:
         return None
     
-    best_stock = None
-    best_similarity = -1
+    pattern_scores, bs_scores = vectorized_weighted_similarity(target_stockid=None, user_id=user_id, 
+                                                              category_stockids=category_stockids, days=days)
     
-    # 각 종목에 대해 유사도 계산
-    for stockid in category_stockids:
-        try:
-            similarity_score = calculate_weighted_similarity(stockid, user_id, days)
-            pattern_similarity = similarity_score['pattern']
-            bs_score = similarity_score['bs']
-            
-            if bs_score > best_similarity:
-                best_similarity = bs_score
-                
-                # 종목 정보 가져오기
-                stock = Stock.objects.get(id=stockid)
-                industry_name = get_industry_name_by_stockid(stockid)
+    if len(bs_scores) == 0 or np.max(bs_scores) == 0:
+        return None
+    
+    best_idx = np.argmax(bs_scores)
+    best_stockid = category_stockids[best_idx]
+    best_similarity = bs_scores[best_idx]
+    best_pattern_score = pattern_scores[best_idx]
+    
+    try:
+        stock = Stock.objects.get(id=best_stockid)
+        industry_name = get_industry_name_by_stockid(best_stockid)
+        
+        best_stock = {
+            'stockid': best_stockid,
+            'name': stock.name,
+            'type': stock.type,
+            'industry_name': industry_name,
+            'similarity_score': best_similarity,
+            'pattern_similarity': best_pattern_score,
+        }
+        
+        return best_stock
+        
+    except Stock.DoesNotExist:
+        return None
 
-                #print(f"DEBUG: 파탄 점수: {pattern_similarity}")
-                
-                best_stock = {
-                    'stockid': stockid,
-                    'name': stock.name,
-                    'type': stock.type,
-                    'industry_name': industry_name or 'N/A',
-                    'similarity_score': bs_score,
-                    'pattern_similarity': pattern_similarity,
-                }
-        except Exception as e:
-            continue
-    
-    return best_stock
+
 
 def count_similar_stocks_by_user(user_id, stock_id):
     try:
@@ -198,14 +307,11 @@ def count_similar_stocks_by_user(user_id, stock_id):
         for mystock in mystocks:
             try:
                 stock = Stock.objects.get(id=mystock.stockid)                
-                # 같은 type인지
                 if stock.type == target_type:
                     same_type_count += 1
                 
-                # 같은 industry_code인지 
                 if stock.industry_code == target_industry_code:
                     same_industry_count += 1
-                
                     
             except Stock.DoesNotExist:
                 continue
@@ -221,9 +327,9 @@ def count_similar_stocks_by_user(user_id, stock_id):
             'same_industry_count': 0,
         }
 
+
 def get_stock_price_history(stock_id):
     try:
-
         price_logs = ClosingPriceLog.objects.filter(stockid=stock_id).order_by('-date')[:30]
         price_logs = list(price_logs)[::-1]  
         stock_name = Stock.objects.get(id=stock_id).name

--- a/stock/views.py
+++ b/stock/views.py
@@ -6,7 +6,15 @@ from similarity.utils import *
 
 class StockSimilarityView(View):
     def get(self, request, stock_id, user_id):
-        bs = calculate_weighted_similarity(stock_id, user_id)['bs']
+        pattern_scores, bs_scores = vectorized_weighted_similarity(
+            target_stockid=stock_id, 
+            user_id=user_id, 
+            category_stockids=[stock_id], 
+            days=30
+        )
+        
+        bs = bs_scores[0] if len(bs_scores) > 0 else 0.0
+        
         # 임시 데이터 세현오빠 수정 부탁해!!
         news = "삼성전자 실적 개선 예상, 반도체 시장 회복세"
         eq = 75  
@@ -33,8 +41,8 @@ class UserCategoryRecommendationView(View):
         # 같은 type, industry 개수 계산
         similarity_counts = count_similar_stocks_by_user(user_id, most_similar_stock['stockid'])
         
-        # 상위 5개 보유 종목 (비교종목)
-        top5_stocks = get_top5_stocks_by_value(user_id)
+        # 상위 5개 보유 종목 (비교종목) - batch_get_user_stock_info 사용
+        top5_stocks = batch_get_user_stock_info(user_id)
         comparison_stocks = []
         for stockid, name, value, cnt, current_price in top5_stocks:
             comparison_stocks.append({


### PR DESCRIPTION
PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트
-[V] 성능 향상

반영 브랜치
ex) bbh -> main

변경 사항
유사도 계산 벡터화 (4.74s -> 0.6s)

기존에는 종목별로 유사도를 개별 계산했지만 벡터화를 통해 한번에 모든 종목의 유사도를 계산하도록 최적화

모든 종목의 가격 데이터를 한번에 조회하고 조회하여 공통된 날짜를 찾아 가격 매트릭스를 생성 (종목 수 * 공통 날짜 수), 또한 DTW를 벡터화 하여 사용자 종목과 모든 카테고리 종목을 동시에 비교하여 numpy 배열 연산으로 가중치를 적용

기존에는 사용자 종목 5개와 카테고리 종목 10-20개를 개별 계산하는 50~100번의 개별 계산이 있었다면 벡터화를 통해 한번의 매트릭스 연산으로 150개 결과를 동시에 생성

우리가 지금 보유하고 있는 데이터는 카테고리에 해당하는 종목들로 50개에서 100개 정도라 의미 있는 속도가 눈에 띄게 향상되었지만 종목 수가 많아질 수록 메모리 사용량이 커지고 DTW 계산이 복잡해질 위험이 있다. 때문에 앞으로 고도화 방안으로는 가격 데이터(종가)나 업종/타입과 같이 하루 정도는 값을 유지하는 데이터를 캐싱하거나 청크 처리로 대용량 데이터를 처리하도록 해야할 것 같다

개선전
<img width="2920" height="1778" alt="image" src="https://github.com/user-attachments/assets/12508224-d343-4757-b39b-6cd5966d7bf4" />

개선후
<img width="2938" height="1784" alt="image" src="https://github.com/user-attachments/assets/2739a9ea-7b89-4800-ba78-b49471fd783d" />


